### PR TITLE
Fix vector paths scanline version-related issues

### DIFF
--- a/korma/src/commonMain/kotlin/com/soywiz/korma/geom/vector/VectorPath.kt
+++ b/korma/src/commonMain/kotlin/com/soywiz/korma/geom/vector/VectorPath.kt
@@ -130,6 +130,7 @@ open class VectorPath(
         lastX = 0.0
         lastY = 0.0
         version = 0
+        scanline.version = version - 1  // ensure scanline will be updated after this "clear" operation
     }
 
     fun setFrom(other: VectorPath) {

--- a/korma/src/commonMain/kotlin/com/soywiz/korma/geom/vector/VectorPath.kt
+++ b/korma/src/commonMain/kotlin/com/soywiz/korma/geom/vector/VectorPath.kt
@@ -236,7 +236,10 @@ open class VectorPath(
     fun containsPoint(x: Double, y: Double): Boolean = containsPoint(x, y, this.winding)
 
     @OptIn(KormaExperimental::class)
-    private val scanline by lazy { PolygonScanline() }
+    private val scanline by lazy { PolygonScanline().also {
+        it.add(this)
+        it.version = this.version
+    } }
     private fun ensureScanline() = scanline.also {
         if (it.version != this.version) {
             it.reset()

--- a/korma/src/commonTest/kotlin/com/soywiz/korma/geom/vector/VectorPathTest.kt
+++ b/korma/src/commonTest/kotlin/com/soywiz/korma/geom/vector/VectorPathTest.kt
@@ -165,7 +165,6 @@ class VectorPathTest {
 
     val path1 = buildPath { rect(0, 0, 100, 100) }
     val path2 = buildPath { rect(10, 10, 150, 80) }
-    val path2clone = path2.clone()  // here VectorPath.version == 0
     val path3 = buildPath { rect(110, 0, 100, 100) }
 
     val path2b = path2.clone().applyTransform(Matrix().scale(2.0))
@@ -178,9 +177,13 @@ class VectorPathTest {
     @Test
     fun testCollides() {
         assertEquals(true, path1.intersectsWith(path2))
-        assertEquals(true, path1.intersectsWith(path2clone))
         assertEquals(true, path2.intersectsWith(path3))
         assertEquals(false, path1.intersectsWith(path3))
+
+        val path2clone = path2.clone()  // here VectorPath.version == 0
+        assertEquals(true, path1.intersectsWith(path2clone))
+        path2clone.clear()
+        assertEquals(false, path1.intersectsWith(path2clone))
     }
 
     @Test

--- a/korma/src/commonTest/kotlin/com/soywiz/korma/geom/vector/VectorPathTest.kt
+++ b/korma/src/commonTest/kotlin/com/soywiz/korma/geom/vector/VectorPathTest.kt
@@ -165,6 +165,7 @@ class VectorPathTest {
 
     val path1 = buildPath { rect(0, 0, 100, 100) }
     val path2 = buildPath { rect(10, 10, 150, 80) }
+    val path2clone = path2.clone()  // here VectorPath.version == 0
     val path3 = buildPath { rect(110, 0, 100, 100) }
 
     val path2b = path2.clone().applyTransform(Matrix().scale(2.0))
@@ -177,6 +178,7 @@ class VectorPathTest {
     @Test
     fun testCollides() {
         assertEquals(true, path1.intersectsWith(path2))
+        assertEquals(true, path1.intersectsWith(path2clone))
         assertEquals(true, path2.intersectsWith(path3))
         assertEquals(false, path1.intersectsWith(path3))
     }


### PR DESCRIPTION
I've found solution for testcase #32: when we construct raw `VectorPath`s, their version is `0`, so is the version of their `PolygonScanline`s. Because of it, `VectorPath`s think their scanlines are up-to-date but they are empty so `intersects` reports `false`.

This is fixed in the first commit and verified via
```kt
val path2clone = path2.clone()
assertEquals(true, path1.intersectsWith(path2clone))  // failed before this commit
```

However, with this change, I still see buggy collision behavior in my game. After it, I've found another version-related issue: in `VectorPath.clear()`. It clears its version but doesn't update the version of its scanline. The second commit fixes it and verifies it via
```kt
path2clone.clear()
assertEquals(false, path1.intersectsWith(path2clone))  // failed before this commit
```

After the second commit, there are no visible issues in my game. I guess the issue can have happened because KorGE clears some paths and then applies them again but with a different transformation. The version (= modification count) remains the same and this was the problem: the scanline wasn't updated. But this is just a guess, I haven't debugged it in my game...

By the way, should I add a commit verifying exactly the test in #32?