### PR TITLE
Proposal for a renamed circle hitshape.

### DIFF
--- a/korma/src/commonMain/kotlin/com/soywiz/korma/geom/vector/VectorBuilder.kt
+++ b/korma/src/commonMain/kotlin/com/soywiz/korma/geom/vector/VectorBuilder.kt
@@ -128,6 +128,8 @@ fun VectorBuilder.arc(x: Double, y: Double, r: Double, start: Double, end: Doubl
 
 fun VectorBuilder.circle(x: Double, y: Double, radius: Double) = arc(x, y, radius, 0.0, PI.toDouble() * 2f)
 
+fun VectorBuilder.sphere(x: Double, y: Double, radius: Double) = arc(x, y, radius, 0.0, PI.toDouble() * 2f)
+
 fun VectorBuilder.ellipse(x: Double, y: Double, rw: Double, rh: Double) {
     val k = .5522848
     val ox = (rw / 2) * k


### PR DESCRIPTION
The current naming is ambigous and frustrating when you dont precisely foster the imports.
I am not 101% happy with `sphere` but it will prevent frustration