### PR TITLE
Easings.EASE_SINE should go all the way up to 1.0.

### DIFF
--- a/korma/src/commonMain/kotlin/com/soywiz/korma/interpolation/Easing.kt
+++ b/korma/src/commonMain/kotlin/com/soywiz/korma/interpolation/Easing.kt
@@ -42,6 +42,7 @@ interface Easing {
 
 private object Easings {
     private const val BOUNCE_10 = 1.70158
+    private const val PI_2 = PI / 2.0;
 
     val SMOOTH = Easing { it * it * (3 - 2 * it) }
 
@@ -92,5 +93,5 @@ private object Easings {
     val EASE_IN_OUT_QUAD =
         Easing { val t = it * 2.0; if (t < 1) (1.0 / 2 * t * t) else (-1.0 / 2 * ((t - 1) * ((t - 1) - 2) - 1)) }
 
-    val EASE_SINE = Easing { sin(it) }
+    val EASE_SINE = Easing { sin(it * PI_2) }
 }

--- a/korma/src/commonTest/kotlin/com/soywiz/korma/interpolation/EasingTest.kt
+++ b/korma/src/commonTest/kotlin/com/soywiz/korma/interpolation/EasingTest.kt
@@ -4,17 +4,26 @@ import kotlin.test.*
 
 class EasingTest {
     @Test
-    fun test() {
+    fun testLinear() {
         assertEquals(0.0, Easing.LINEAR(0.0))
         assertEquals(0.1, Easing.LINEAR(0.1))
         assertEquals(0.5, Easing.LINEAR(0.5))
         assertEquals(0.9, Easing.LINEAR(0.9))
         assertEquals(1.0, Easing.LINEAR(1.0))
+    }
 
+    @Test
+    fun testSmooth() {
         assertEquals(0.0, Easing.SMOOTH(0.0))
         assertEquals(0.028000000000000004, Easing.SMOOTH(0.1))
         assertEquals(0.5, Easing.SMOOTH(0.5))
         assertEquals(0.972, Easing.SMOOTH(0.9))
         assertEquals(1.0, Easing.SMOOTH(1.0))
+    }
+
+    @Test
+    fun testSine() {
+        assertEquals(0.0, Easing.EASE_SINE(0.0))
+        assertEquals(1.0, Easing.EASE_SINE(1.0))
     }
 }


### PR DESCRIPTION
Right now, EASE_SINE(0) == 0.0, but EASE_SINE(1) ~= 0.84, which is incorrect. EASE_SINE(1.57) does yield 1.0, but that's not how easings are supposed to work :)

This corrects the issue so that EASE_SINE(1) == 1.0 and also adds a test for it.

I've successfully build this change locally with `./gradlew build` on Fedora 32.

P.S. you might think about creating a PI_2-type constant that's reachable from the entire project.