### PR TITLE
Support single argument for inflate

### DIFF
--- a/korma/src/commonMain/kotlin/com/soywiz/korma/geom/Rectangle.kt
+++ b/korma/src/commonMain/kotlin/com/soywiz/korma/geom/Rectangle.kt
@@ -129,12 +129,12 @@ data class Rectangle(
         return out.setTo(x, y, ow, oh)
     }
 
-    fun inflate(dx: Double, dy: Double) {
+    fun inflate(dx: Double, dy: Double = dx) {
         x -= dx; width += 2 * dx
         y -= dy; height += 2 * dy
     }
-    fun inflate(dx: Float, dy: Float) = inflate(dx.toDouble(), dy.toDouble())
-    fun inflate(dx: Int, dy: Int) = inflate(dx.toDouble(), dy.toDouble())
+    fun inflate(dx: Float, dy: Float = dx) = inflate(dx.toDouble(), dy.toDouble())
+    fun inflate(dx: Int, dy: Int = dx) = inflate(dx.toDouble(), dy.toDouble())
 
     fun clear() = setTo(0.0, 0.0, 0.0, 0.0)
 


### PR DESCRIPTION
Inflating a rectangle identically to all directions is a frequent operation for me, for example:
```kotlin
val borderRect = innerRect.inflate(1, 1)
```

This PR adds an ability to pass a single argument to `inflate`:
```kotlin
val borderRect = innerRect.inflate(1)
```

The proposed implementation (making default `dy = dx`) is inspired by [`Context2d.scale(*, *)`](https://github.com/korlibs/korim/blob/7132a30222dbd98a8d6dbc9e679d873eb71af4e9/korim/src/commonMain/kotlin/com/soywiz/korim/vector/Context2d.kt#L255).

Another way of doing it is as follows:
```kotlin
fun Rectangle.inflate(offsets: Double) = inflate(offsets, offsets)
fun Rectangle.inflate(offsets: Float) = inflate(offsets.toDouble())
fun Rectangle.inflate(offsets: Int) = inflate(offsets.toDouble())
```

If you think the latter is better (actually, I think it is), I can recreate the PR.