### PR TITLE
Add corners properties for IRectangleInt

### DIFF
--- a/korma/src/commonMain/kotlin/com/soywiz/korma/geom/Rectangle.kt
+++ b/korma/src/commonMain/kotlin/com/soywiz/korma/geom/Rectangle.kt
@@ -306,6 +306,19 @@ inline fun IRectangleInt.anchor(ax: Number, ay: Number): IPointInt = anchor(ax.t
 
 val IRectangleInt.center get() = anchor(0.5, 0.5)
 
+val IRectangleInt.topLeft get() = PointInt(left, top)
+val IRectangleInt.topRight get() = PointInt(right, top)
+val IRectangleInt.bottomLeft get() = PointInt(left, bottom)
+val IRectangleInt.bottomRight get() = PointInt(right, bottom)
+
+val IRectangleInt.x2: Int get() = x + width - 1
+val IRectangleInt.y2: Int get() = y + height - 1
+
+val IRectangleInt.topLeft2 get() = PointInt(x, y)
+val IRectangleInt.topRight2 get() = PointInt(x2, y)
+val IRectangleInt.bottomLeft2 get() = PointInt(x, y2)
+val IRectangleInt.bottomRight2 get() = PointInt(x2, y2)
+
 ///////////////////////////
 
 fun Iterable<Rectangle>.bounds(target: Rectangle = Rectangle()): Rectangle {


### PR DESCRIPTION
For integer rectangle, it's very convenient to have different types of corners. I've seen inner corners properties (with "2" suffix) in another library, so it's probably a good practice and a used name.

This PR:
1. Adds simple corners properties (same as for IRectangle: topLeft, topRight, bottomLeft, bottomRight).
2. Adds inner corners coordinates (`x2 = right - 1`, `y2 = bottom - 1`).
3. Adds inner corners properties (topLeft2, topRight2, bottomLeft2, bottomRight2).

The generated points are intentionally mutable: it's convenient to use them in computations after obtaining. The same happens in [corners properties of Rectangle](https://github.com/korlibs/korma/blob/fb7c2de33571795c69d606b59c1ed0e1f12ad83d/korma/src/commonMain/kotlin/com/soywiz/korma/geom/Rectangle.kt#L33-L36) so let's use the logic.

By the way, I think corners properties of Rectangle should be lifted out of it and made as extensions of IRectangle. It'll also make it clear that the returned objects don't modify the Rectangle. If it's OK, I'll create a separate PR:
```kotlin
val IRectangle.topLeft get() = Point(left, top)
val IRectangle.topRight get() = Point(right, top)
val IRectangle.bottomLeft get() = Point(left, bottom)
val IRectangle.bottomRight get() = Point(right, bottom)
```