### PR TITLE
Make the argument more generic

### DIFF
--- a/korma/src/commonMain/kotlin/com/soywiz/korma/geom/Rectangle.kt
+++ b/korma/src/commonMain/kotlin/com/soywiz/korma/geom/Rectangle.kt
@@ -308,7 +308,7 @@ val IRectangleInt.center get() = anchor(0.5, 0.5)
 
 ///////////////////////////
 
-fun Iterable<Rectangle>.bounds(target: Rectangle = Rectangle()): Rectangle {
+fun Iterable<IRectangle>.bounds(target: Rectangle = Rectangle()): Rectangle {
     var first = true
     var left = 0.0
     var right = 0.0


### PR DESCRIPTION
I think it's better to use the supertype to allow its usage with constants.